### PR TITLE
[feat/#11] : 로그인 및 회원 정보 입력 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,11 @@
       "dependencies": {
         "@ducanh2912/next-pwa": "^10.2.9",
         "autoprefixer": "^10.4.20",
+        "axios": "^1.7.9",
         "next": "15.1.7",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "zustand": "^5.0.3"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -2695,7 +2697,7 @@
       "version": "19.0.10",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.10.tgz",
       "integrity": "sha512-JuRQ9KXLEjaUNjTWpzuR231Z2WpIwczOkBEIvbHNCzQefFIT0L8IqE6NV6ULLyC1SI/i234JnDoMkfg+RjQj2g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -3445,6 +3447,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/at-least-node": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
@@ -3514,6 +3522,17 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
+      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -3863,6 +3882,18 @@
         "simple-swizzle": "^0.2.2"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -3948,7 +3979,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -4074,6 +4105,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/detect-libc": {
@@ -4975,6 +5015,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -5005,6 +5065,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fraction.js": {
@@ -7007,6 +7082,12 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -9369,6 +9450,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.3.tgz",
+      "integrity": "sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "next": "15.1.7",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "zustand": "^5.0.3"
+        "zustand": "^3.7.0"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -2697,7 +2697,7 @@
       "version": "19.0.10",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.10.tgz",
       "integrity": "sha512-JuRQ9KXLEjaUNjTWpzuR231Z2WpIwczOkBEIvbHNCzQefFIT0L8IqE6NV6ULLyC1SI/i234JnDoMkfg+RjQj2g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -3979,7 +3979,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -9453,30 +9453,18 @@
       }
     },
     "node_modules/zustand": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.3.tgz",
-      "integrity": "sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-3.7.0.tgz",
+      "integrity": "sha512-USzVzLGrvZ8VK1/sEsOAmeqa8N7D3OBdZskVaL7DL89Q4QLTYD053iIlZ5KDidyZ+Od80Dttin/f8ZulOLFFDQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=12.20.0"
+        "node": ">=12.7.0"
       },
       "peerDependencies": {
-        "@types/react": ">=18.0.0",
-        "immer": ">=9.0.6",
-        "react": ">=18.0.0",
-        "use-sync-external-store": ">=1.2.0"
+        "react": ">=16.8"
       },
       "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "immer": {
-          "optional": true
-        },
         "react": {
-          "optional": true
-        },
-        "use-sync-external-store": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -11,9 +11,11 @@
   "dependencies": {
     "@ducanh2912/next-pwa": "^10.2.9",
     "autoprefixer": "^10.4.20",
+    "axios": "^1.7.9",
     "next": "15.1.7",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "zustand": "^5.0.3"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "next": "15.1.7",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "zustand": "^5.0.3"
+    "zustand": "^3.7.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/api/axios-instance.ts
+++ b/src/api/axios-instance.ts
@@ -1,0 +1,68 @@
+import { useRouter } from "next/navigation";
+import axios from "axios";
+
+import { useAuthStore } from "@store/user-store";
+import { reissue } from "./user-api";
+
+const router = useRouter();
+
+const axiosInstance = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_BASE_URL,
+  withCredentials: true,
+  headers: {
+    "Content-Type": "application/json",
+  },
+});
+
+// 요청 인터셉터
+axiosInstance.interceptors.request.use(
+  (config) => {
+    const { accessToken } = useAuthStore.getState();
+    if (accessToken) config.headers["Authorization"] = accessToken;
+    return config;
+  },
+  (error) => Promise.reject(error)
+);
+
+// 응답 인터셉터
+axiosInstance.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config;
+
+    if (
+      error.response &&
+      !originalRequest._retry &&
+      error.response.status === 401
+    ) {
+      originalRequest._retry = true;
+
+      const { refreshToken } = useAuthStore.getState();
+      if (!refreshToken) {
+        router.replace("/login");
+        return Promise.reject(error);
+      }
+
+      try {
+        const response = await reissue(refreshToken);
+
+        if (response.data.is_success) {
+          const newAccessToken = response.data.data.accessToken;
+          useAuthStore.getState().setAccessToken(newAccessToken);
+
+          originalRequest.headers["Authorization"] = newAccessToken;
+          return axiosInstance(originalRequest);
+        } else {
+          useAuthStore.getState().clearRefreshToken();
+          useAuthStore.getState().clearAccessToken();
+          router.replace("/login");
+        }
+      } catch (error) {
+        useAuthStore.getState().clearAccessToken();
+        router.replace("/login");
+      }
+    }
+
+    return Promise.reject(error);
+  }
+);

--- a/src/api/user-api.ts
+++ b/src/api/user-api.ts
@@ -1,7 +1,21 @@
+import { useAuthStore } from "@store/user-store";
 import axios from "axios";
 
+const baseURL = process.env.NEXT_PUBLIC_BASE_URL;
+
+// 토큰 재발급
+export const reissue = async (refreshToken: string) => {
+  return axios.get(`${baseURL}/tokens/issue`, {
+    withCredentials: true,
+    headers: {
+      "Content-Type": "application/json",
+      refreshToken: refreshToken,
+    },
+  });
+};
+
 // 회원가입
-const register = async (
+export const register = async (
   registerToken: string,
   nickname: string,
   birth: string
@@ -9,13 +23,19 @@ const register = async (
   try {
     const response = await axios
       .create({
-        baseURL: process.env.NEXT_PUBLIC_BASE_URL,
+        baseURL: baseURL,
+        withCredentials: true,
         headers: {
           "Content-Type": "applicaiton/json",
           registerToken: registerToken,
         },
       })
-      .post(`users/register`, { nickname, birth });
+      .post(`/users/register`, { nickname, birth });
+
+    const { refreshToken, accessToken } = response.data.data;
+
+    useAuthStore.getState().setRefreshToken(refreshToken);
+    useAuthStore.getState().setAccessToken(accessToken);
 
     return response.data;
   } catch (error) {

--- a/src/api/user-api.ts
+++ b/src/api/user-api.ts
@@ -1,0 +1,26 @@
+import axios from "axios";
+
+// 회원가입
+const register = async (
+  registerToken: string,
+  nickname: string,
+  birth: string
+) => {
+  try {
+    const response = await axios
+      .create({
+        baseURL: process.env.NEXT_PUBLIC_BASE_URL,
+        headers: {
+          "Content-Type": "applicaiton/json",
+          registerToken: registerToken,
+        },
+      })
+      .post(`users/register`, { nickname, birth });
+
+    return response.data;
+  } catch (error) {
+    console.error("회원가입 실패", error);
+  }
+};
+
+// 닉네임 중복 확인

--- a/src/api/user-api.ts
+++ b/src/api/user-api.ts
@@ -1,5 +1,6 @@
-import { useAuthStore } from "@store/user-store";
 import axios from "axios";
+
+import { useAuthStore } from "@store/user-store";
 
 const baseURL = process.env.NEXT_PUBLIC_BASE_URL;
 

--- a/src/api/user-api.ts
+++ b/src/api/user-api.ts
@@ -26,11 +26,11 @@ export const register = async (
         baseURL: baseURL,
         withCredentials: true,
         headers: {
-          "Content-Type": "applicaiton/json",
+          "Content-Type": "application/json",
           registerToken: registerToken,
         },
       })
-      .post(`/users/register`, { nickname, birth });
+      .post(`/users/register`, { nickName: nickname, birth });
 
     const { refreshToken, accessToken } = response.data.data;
 
@@ -44,3 +44,24 @@ export const register = async (
 };
 
 // 닉네임 중복 확인
+export const checkNickname = async (
+  registerToken: string,
+  nickname: string
+) => {
+  try {
+    const response = await axios
+      .create({
+        baseURL: baseURL,
+        withCredentials: true,
+        headers: {
+          "Content-Type": "application/json",
+          registerToken: registerToken,
+        },
+      })
+      .post(`/users/nickname/check`, { nickName: nickname });
+
+    return response.data;
+  } catch (error) {
+    console.error("닉네임 중복 확인 실패", error);
+  }
+};

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,11 +1,33 @@
+"use client"; // 리액트 훅 부분 컴포넌트 분리 or 서버 액션 사용해서 SSR 적용 필요
+
+import { useRouter, useSearchParams } from "next/navigation";
 import Image from "next/image";
+import { useEffect } from "react";
 
 import Button from "@components/button/button";
+import { useAuthStore } from "@store/user-store";
 
 import notification from "@assets/notification.svg";
 import kakao from "@assets/svg/kakao.svg";
 
 const Login = () => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    const refreshToken = searchParams.get("refreshToken");
+    const accessToken = searchParams.get("accessToken");
+
+    if (
+      typeof accessToken === "string" &&
+      typeof refreshToken === "string"
+    ) {
+      useAuthStore.getState().setAccessToken(accessToken);
+      useAuthStore.getState().setRefreshToken(refreshToken);
+      router.replace("/");
+    }
+  }, []);
+
   return (
     <main className="w-full h-screen bg-white flex flex-col justify-center items-center">
       {/* 로고 영역 */}

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,5 +1,101 @@
+"use client"; // useState 부분 컴포넌트 분리 or 서버 액션 사용해서 SSR 적용 필요
+
+import { useState } from "react";
+
+import Header from "@components/header";
+import Blank from "@components/button/blank";
+import EventButton from "@components/button/event-button";
+import CheckButton from "@components/button/check-button";
+import Button from "@components/button/button";
+
+import cancel from "@assets/svg/cancel.svg";
+
 const Register = () => {
-  return <div>첫 회원일 경우 정보 받기</div>;
+  const [nickname, setNickname] = useState("");
+  const [birth, setBirth] = useState("");
+  const [isCheckNickname, SetIsCheckNickname] = useState(false);
+
+  const onChangeNickname = (e: any) => {
+    setNickname(e.target.value);
+  };
+
+  const onChangeBirth = (e: any) => {
+    setBirth(e.target.value);
+  };
+
+  return (
+    <main className="bg-white">
+      <Header
+        leftChild={<Blank />}
+        rightChild={<EventButton icon={cancel} command="register" />}
+      />
+
+      <div className="h-screen flex flex-col justify-center p-5">
+        {/* 타이틀 구역 */}
+        <section className="text-2xl font-semibold mb-24">
+          필수 정보를 입력해주세요!
+        </section>
+
+        {/* 입력 구역 */}
+        <section className="flex flex-col gap-14 mb-14">
+          <div className="flex flex-col">
+            <label className="mb-7 text-lg font-medium">
+              닉네임을 입력해주세요.
+            </label>
+            <div className="flex items-center relative">
+              <input
+                type="text"
+                placeholder="한글, 영문, 숫자 중 2가지 이상 8자 이내 입력"
+                className={`w-full py-2 pr-16 text-sm outline-none border-b-[1px] ${
+                  nickname ? "border-black" : "border-[#D9D9D9]"
+                }`}
+                value={nickname}
+                onChange={onChangeNickname}
+              />
+              <div className="absolute right-0 z-10">
+                {isCheckNickname ? (
+                  <CheckButton
+                    text="확인완료"
+                    type="check"
+                    onClick={() => {}}
+                  />
+                ) : (
+                  <CheckButton
+                    text="중복확인"
+                    type="uncheck"
+                    onClick={() => {}}
+                  />
+                )}
+              </div>
+            </div>
+          </div>
+          <div className="flex flex-col">
+            <label className="mb-7 text-lg font-medium">
+              생년월일을 입력해주세요.
+            </label>
+            <input
+              type="text"
+              placeholder="예) 2000-01-01"
+              className={`w-full py-2 flex justify-between text-sm outline-none border-b-[1px] ${
+                birth ? "border-black" : "border-[#D9D9D9]"
+              }`}
+              value={birth}
+              onChange={onChangeBirth}
+            />
+          </div>
+        </section>
+      </div>
+
+      {/* 버튼 구역 */}
+      <section className="max-w-[480px] w-full fixed bottom-5">
+        {nickname && birth ? (
+          <Button text="뉴퀴즈 시작하기" type="active" link="/" />
+        ) : (
+          <Button text="뉴퀴즈 시작하기" type="inactive" link="" />
+        )}
+      </section>
+    </main>
+  );
 };
 
 export default Register;

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation";
 import { IButton } from "@interface/props";
 import Image from "next/image";
 
-const Button = ({ icon, text, type, link }: IButton) => {
+const Button = ({ icon, text, type, link, onClick }: IButton) => {
   const router = useRouter();
 
   const buttonClass = {
@@ -14,11 +14,21 @@ const Button = ({ icon, text, type, link }: IButton) => {
     inactive: "bg-[#E2E2E2] text-[#888888] font-semibold text-sm",
   };
 
+  const onClickButton = () => {
+    if (link) {
+      router.push(link);
+    }
+
+    if (onClick) {
+      onClick();
+    }
+  };
+
   return (
     <div className="px-5">
       <button
         className={`w-full h-14 rounded-[10px] ${buttonClass[type]}`}
-        onClick={() => router.push(link)}
+        onClick={onClickButton}
       >
         <div className="flex justify-center gap-2">
           {icon ? (

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -10,8 +10,8 @@ const Button = ({ icon, text, type, link }: IButton) => {
 
   const buttonClass = {
     kakao: "bg-[#FEE500] text-black",
-    active: "bg-[#484848] text-white",
-    inactive: "bg-[#E2E2E2] text-[#888888]",
+    active: "bg-[#484848] text-white font-semibold text-sm",
+    inactive: "bg-[#E2E2E2] text-[#888888] font-semibold text-sm",
   };
 
   return (

--- a/src/components/button/check-button.tsx
+++ b/src/components/button/check-button.tsx
@@ -1,9 +1,14 @@
 import { ICheckButton } from "@interface/props";
 
-const CheckButton = ({ text, onClick }: ICheckButton) => {
+const CheckButton = ({ text, type, onClick }: ICheckButton) => {
+  const buttonClass = {
+    uncheck: "bg-lavender text-white",
+    check: "bg-[#FBFAFF] text-lavender border-[1px] border-lavender",
+  };
+
   return (
     <button
-      className="w-[60px] h-[26px] bg-lavender text-[11px] text-white font-semibold rounded-[20px]"
+      className={`${buttonClass[type]} w-[60px] h-[26px] text-[11px] font-semibold rounded-[20px]`}
       onClick={onClick}
     >
       {text}

--- a/src/components/button/check-button.tsx
+++ b/src/components/button/check-button.tsx
@@ -3,7 +3,8 @@ import { ICheckButton } from "@interface/props";
 const CheckButton = ({ text, type, onClick }: ICheckButton) => {
   const buttonClass = {
     uncheck: "bg-lavender text-white",
-    check: "bg-[#FBFAFF] text-lavender border-[1px] border-lavender",
+    check:
+      "bg-[#FBFAFF] text-lavender border-[1px] border-lavender cursor-default",
   };
 
   return (

--- a/src/components/button/check-button.tsx
+++ b/src/components/button/check-button.tsx
@@ -1,0 +1,14 @@
+import { ICheckButton } from "@interface/props";
+
+const CheckButton = ({ text, onClick }: ICheckButton) => {
+  return (
+    <button
+      className="w-[60px] h-[26px] bg-lavender text-[11px] text-white font-semibold rounded-[20px]"
+      onClick={onClick}
+    >
+      {text}
+    </button>
+  );
+};
+
+export default CheckButton;

--- a/src/components/button/event-button.tsx
+++ b/src/components/button/event-button.tsx
@@ -1,8 +1,24 @@
+"use client";
+
 import Image from "next/image";
+import { useRouter } from "next/navigation";
 
 import { IEventButton } from "@interface/props";
 
-const EventButton = ({ icon, onClick }: IEventButton) => {
+const EventButton = ({ icon, command }: IEventButton) => {
+  const router = useRouter();
+
+  const onClick = () => {
+    switch (command) {
+      case "register": {
+        router.back();
+        break;
+      }
+      default:
+        break;
+    }
+  };
+
   return (
     <button onClick={onClick}>
       <Image src={icon} width={24} height={24} alt="이벤트버튼" />

--- a/src/components/button/small-button.tsx
+++ b/src/components/button/small-button.tsx
@@ -1,13 +1,6 @@
 import { ISmallButton } from "@interface/props";
 
 const SmallButton = ({ text, type, link, onClick }: ISmallButton) => {
-  // type 속성에 맞는 스타일이 변경되는 클래스 생성 필요
-  // const buttonClass = {};
-  // buttonClass[type]
-  // 네, 아니오 버튼 & 취소, 탈퇴 버튼
-  // 상, 중, 하 버튼
-  // 기사 카테고리 선택 버튼
-
   const buttonClass = {
     inactive: "w-20 h-11 bg-[#F2F2F2] text-[#484848]",
     active: "w-20 h-11 bg-black text-white",

--- a/src/interface/props.ts
+++ b/src/interface/props.ts
@@ -33,7 +33,7 @@ export interface IButton {
 
 export interface IEventButton {
   icon: string;
-  onClick: () => void;
+  command: string;
 }
 
 export interface ISmallButton {
@@ -41,6 +41,11 @@ export interface ISmallButton {
   type: "inactive" | "active" | "negative" | "positive";
   link?: string;
   onClick?: () => void;
+}
+
+export interface ICheckButton {
+  text: string;
+  onClick: () => void;
 }
 
 /* 사용자 인터페이스 */

--- a/src/interface/props.ts
+++ b/src/interface/props.ts
@@ -45,6 +45,7 @@ export interface ISmallButton {
 
 export interface ICheckButton {
   text: string;
+  type: "uncheck" | "check";
   onClick: () => void;
 }
 

--- a/src/interface/props.ts
+++ b/src/interface/props.ts
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import { MouseEventHandler, ReactNode } from "react";
 
 /* 공통 인터페이스 */
 export interface IHeader {
@@ -28,7 +28,8 @@ export interface IButton {
   icon?: string;
   text: string;
   type: "kakao" | "active" | "inactive";
-  link: string;
+  link?: string;
+  onClick?: () => {};
 }
 
 export interface IEventButton {
@@ -46,7 +47,7 @@ export interface ISmallButton {
 export interface ICheckButton {
   text: string;
   type: "uncheck" | "check";
-  onClick: () => void;
+  onClick: MouseEventHandler;
 }
 
 /* 사용자 인터페이스 */

--- a/src/interface/state.ts
+++ b/src/interface/state.ts
@@ -1,0 +1,9 @@
+// 사용자 store state
+export interface IAuthStore {
+  refreshToken: string | null;
+  setRefreshToken: (token: string) => void;
+  clearRefreshToken: () => void;
+  accessToken: string | null;
+  setAccessToken: (token: string) => void;
+  clearAccessToken: () => void;
+}

--- a/src/store/user-store.ts
+++ b/src/store/user-store.ts
@@ -1,15 +1,23 @@
-import { create } from "zustand";
+import create from "zustand";
+import { persist } from "zustand/middleware";
 
 import { IAuthStore } from "@interface/state";
 
 // 사용자 토큰 저장
-export const useAuthStore = create<IAuthStore>((set) => ({
-  refreshToken: null,
-  setRefreshToken: (token) => set({ refreshToken: token }),
-  clearRefreshToken: () => set({ refreshToken: null }),
-  accessToken: null,
-  setAccessToken: (token) => set({ accessToken: token }),
-  clearAccessToken: () => set({ accessToken: null }),
-}));
+export const useAuthStore = create<IAuthStore>(
+  persist(
+    (set) => ({
+      refreshToken: null,
+      setRefreshToken: (token: string) => set({ refreshToken: token }),
+      clearRefreshToken: () => set({ refreshToken: null }),
+      accessToken: null,
+      setAccessToken: (token: string) => set({ accessToken: token }),
+      clearAccessToken: () => set({ accessToken: null }),
+    }),
+    {
+      name: "auth-storage",
+    }
+  ) as any
+);
 
 // 사용자 정보 저장

--- a/src/store/user-store.ts
+++ b/src/store/user-store.ts
@@ -1,1 +1,15 @@
+import { create } from "zustand";
+
+import { IAuthStore } from "@interface/state";
+
+// 사용자 토큰 저장
+export const useAuthStore = create<IAuthStore>((set) => ({
+  refreshToken: null,
+  setRefreshToken: (token) => set({ refreshToken: token }),
+  clearRefreshToken: () => set({ refreshToken: null }),
+  accessToken: null,
+  setAccessToken: (token) => set({ accessToken: token }),
+  clearAccessToken: () => set({ accessToken: null }),
+}));
+
 // 사용자 정보 저장

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -11,11 +11,12 @@ export default {
       colors: {
         background: "var(--background)",
         foreground: "var(--foreground)",
+        lavender: "#6D2FF2",
+        "bright-lavender": "#B287FD",
+        "mist-lavender": "#EAE1FF",
         "void-black": "#262626",
         "rasin-black": "#212121",
         "light-gray": "#D8D9DD",
-        "bright-lavender": "#B287FD",
-        "mist-lavender": "#EAE1FF",
         "lime-green": "#B2F142",
       },
       boxShadow: {


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #11

### 💡 작업내용
- 카카오 로그인 연결
- 닉네임 중복확인 연결
- 회원 등록 연결
- 닉네임 및 생년월일 정규식 확인

### 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/fae34b29-0810-4ae1-98a2-2f5219f260d4)

### 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
- 토큰 없을 시 자동으로 로그인 페이지로 이동하는 기능 필요