### PR TITLE
[feat/#27] : 분야별 기사 조회 API 연결

### DIFF
--- a/src/api/axios-instance.ts
+++ b/src/api/axios-instance.ts
@@ -1,10 +1,7 @@
-import { useRouter } from "next/navigation";
 import axios from "axios";
 
 import { useAuthStore } from "@store/user-store";
 import { reissue } from "./user-api";
-
-const router = useRouter();
 
 const axiosInstance = axios.create({
   baseURL: process.env.NEXT_PUBLIC_BASE_URL,
@@ -39,7 +36,7 @@ axiosInstance.interceptors.response.use(
 
       const { refreshToken } = useAuthStore.getState();
       if (!refreshToken) {
-        router.replace("/login");
+        window.location.href = "/login";
         return Promise.reject(error);
       }
 
@@ -47,7 +44,7 @@ axiosInstance.interceptors.response.use(
         const response = await reissue(refreshToken);
 
         if (response.data.is_success) {
-          const newAccessToken = response.data.data.accessToken;
+          const newAccessToken = `Bearer ${response.data.data.accessToken}`;
           useAuthStore.getState().setAccessToken(newAccessToken);
 
           originalRequest.headers["Authorization"] = newAccessToken;
@@ -55,11 +52,11 @@ axiosInstance.interceptors.response.use(
         } else {
           useAuthStore.getState().clearRefreshToken();
           useAuthStore.getState().clearAccessToken();
-          router.replace("/login");
+          window.location.href = "/login";
         }
       } catch (error) {
         useAuthStore.getState().clearAccessToken();
-        router.replace("/login");
+        window.location.href = "/login";
       }
     }
 

--- a/src/api/axios-instance.ts
+++ b/src/api/axios-instance.ts
@@ -66,3 +66,5 @@ axiosInstance.interceptors.response.use(
     return Promise.reject(error);
   }
 );
+
+export default axiosInstance;

--- a/src/api/news-api.ts
+++ b/src/api/news-api.ts
@@ -1,0 +1,6 @@
+import axiosInstance from "./axios-instance";
+
+// 분야별 기사 조회
+export const readNewsAll = async (category: string) => {
+  return axiosInstance.get(`/news?category=${category}`);
+};

--- a/src/api/news-api.ts
+++ b/src/api/news-api.ts
@@ -5,5 +5,6 @@ export const readNewsAll = async (category: string) => {
   const response = await axiosInstance.get(
     `/news?category=${category}`
   );
+
   return response.data;
 };

--- a/src/api/news-api.ts
+++ b/src/api/news-api.ts
@@ -2,5 +2,8 @@ import axiosInstance from "./axios-instance";
 
 // 분야별 기사 조회
 export const readNewsAll = async (category: string) => {
-  return axiosInstance.get(`/news?category=${category}`);
+  const response = await axiosInstance.get(
+    `/news?category=${category}`
+  );
+  return response.data;
 };

--- a/src/api/user-api.ts
+++ b/src/api/user-api.ts
@@ -36,7 +36,7 @@ export const register = async (
     const { refreshToken, accessToken } = response.data.data;
 
     useAuthStore.getState().setRefreshToken(refreshToken);
-    useAuthStore.getState().setAccessToken(accessToken);
+    useAuthStore.getState().setAccessToken(`Bearer ${accessToken}`);
 
     return response.data;
   } catch (error) {

--- a/src/app/article/page.tsx
+++ b/src/app/article/page.tsx
@@ -8,10 +8,13 @@ import BackButton from "@components/button/back-button";
 import Blank from "@components/button/blank";
 import Category from "@components/category";
 import ArticleList from "@container/article-list";
+import { readNewsAll } from "@api/news-api";
 
 // 기사 카테고리별 api 연결 필요
 const Article = () => {
   const [isLoading, setIsLoading] = useState(true);
+  const [articles, setArticles] = useState([]);
+  const [category, setCategory] = useState("정치");
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -20,6 +23,19 @@ const Article = () => {
 
     return () => clearTimeout(timer);
   }, []);
+
+  useEffect(() => {
+    getArticles(category);
+  }, [category]);
+
+  const getArticles = async (category: string) => {
+    const response = await readNewsAll(category);
+    setArticles(response.data.news);
+  };
+
+  const onCategorySelect = (category: string) => {
+    setCategory(category);
+  };
 
   return (
     <main>
@@ -36,8 +52,8 @@ const Article = () => {
 
           {/* 카테고리 & 기사 리스트 구역 */}
           <section className="pt-16">
-            <Category />
-            <ArticleList />
+            <Category onCategorySelect={onCategorySelect} />
+            <ArticleList articles={articles} />
           </section>
         </>
       )}

--- a/src/components/article/article-item.tsx
+++ b/src/components/article/article-item.tsx
@@ -1,7 +1,13 @@
 import { IArticleItem } from "@interface/props";
 import { useRouter } from "next/navigation";
 
-const ArticleItem = ({ newsId, title, date, source }: IArticleItem) => {
+const ArticleItem = ({
+  id,
+  newsId,
+  title,
+  date,
+  source,
+}: IArticleItem) => {
   const router = useRouter();
 
   const onClickArticle = () => {
@@ -14,7 +20,7 @@ const ArticleItem = ({ newsId, title, date, source }: IArticleItem) => {
       onClick={onClickArticle}
     >
       {/* 기사 번호 */}
-      <div className="text-lavender font-semibold mr-2">{newsId}</div>
+      <div className="text-lavender font-semibold mr-2">{id}</div>
 
       {/* 기사 정보 */}
       <div className="flex flex-col gap-1 w-full">

--- a/src/components/article/article-item.tsx
+++ b/src/components/article/article-item.tsx
@@ -1,11 +1,11 @@
 import { IArticleItem } from "@interface/props";
 import { useRouter } from "next/navigation";
 
-const ArticleItem = ({ id, title, date, source }: IArticleItem) => {
+const ArticleItem = ({ newsId, title, date, source }: IArticleItem) => {
   const router = useRouter();
 
   const onClickArticle = () => {
-    router.push(`article/${id}`);
+    router.push(`article/${newsId}`);
   };
 
   return (
@@ -14,7 +14,7 @@ const ArticleItem = ({ id, title, date, source }: IArticleItem) => {
       onClick={onClickArticle}
     >
       {/* 기사 번호 */}
-      <div className="text-lavender font-semibold mr-2">{id}</div>
+      <div className="text-lavender font-semibold mr-2">{newsId}</div>
 
       {/* 기사 정보 */}
       <div className="flex flex-col gap-1 w-full">

--- a/src/components/category.tsx
+++ b/src/components/category.tsx
@@ -2,17 +2,21 @@
 
 import { useState } from "react";
 
-const Category = () => {
+import { ICategory } from "@interface/props";
+
+const Category = ({ onCategorySelect }: ICategory) => {
   const [select, setSelect] = useState(0);
+  const categories = ["정치", "경제", "사회", "기타"];
 
   const onClickCategory = (index: number) => {
     setSelect(index);
+    onCategorySelect(categories[index]);
   };
 
   return (
     <nav>
       <ul className="flex justify-around bg-[#F7F5FF] rounded-[20px] mx-5 text-sm">
-        {["정치", "경제", "사회", "기타"].map((category, index) => (
+        {categories.map((category, index) => (
           <li
             key={index}
             onClick={() => onClickCategory(index)}

--- a/src/container/article-list.tsx
+++ b/src/container/article-list.tsx
@@ -8,6 +8,7 @@ const ArticleList = ({ articles }: IArticleItemList) => {
       {articles.length > 0 ? (
         articles.map((article, index) => (
           <ArticleItem
+            key={article.newsId}
             newsId={index + 1}
             title={article.title}
             date={article.date}

--- a/src/container/article-list.tsx
+++ b/src/container/article-list.tsx
@@ -8,8 +8,9 @@ const ArticleList = ({ articles }: IArticleItemList) => {
       {articles.length > 0 ? (
         articles.map((article, index) => (
           <ArticleItem
-            key={article.newsId}
-            newsId={index + 1}
+            key={index + 1}
+            id={index + 1}
+            newsId={article.newsId}
             title={article.title}
             date={article.date}
             source={article.source}

--- a/src/container/article-list.tsx
+++ b/src/container/article-list.tsx
@@ -1,26 +1,26 @@
 import ArticleItem from "@components/article/article-item";
 
-const ArticleList = () => {
+import { IArticleItemList } from "@interface/props";
+
+const ArticleList = ({ articles }: IArticleItemList) => {
   return (
     <main className="mx-8">
-      <ArticleItem
-        id={25}
-        title="[사설] 러시아·북한 편에 선 미국, 안보 지각변동 대비하라"
-        date="2025-02-26"
-        source="한국일보"
-      />
-      <ArticleItem
-        id={25}
-        title="[사설] 러시아·북한 편에 선 미국, 안보 지각변동 대비하라"
-        date="2025-02-26"
-        source="한국일보"
-      />
-      <ArticleItem
-        id={25}
-        title="[사설] 러시아·북한 편에 선 미국, 안보 지각변동 대비하라"
-        date="2025-02-26"
-        source="한국일보"
-      />
+      {articles.length > 0 ? (
+        articles.map((article, index) => (
+          <ArticleItem
+            newsId={index + 1}
+            title={article.title}
+            date={article.date}
+            source={article.source}
+          />
+        ))
+      ) : (
+        <p className="mt-[100%] text-center text-sm font">
+          해당 분야에 존재하는 기사가 없습니다.
+          <br />
+          다른 분야를 선택해주세요
+        </p>
+      )}
     </main>
   );
 };

--- a/src/interface/props.ts
+++ b/src/interface/props.ts
@@ -60,8 +60,16 @@ export interface IStudyDuration {
 /* 사용자 인터페이스 */
 
 /* 기사 인터페이스 */
+export interface ICategory {
+  onCategorySelect: (category: string) => void;
+}
+
+export interface IArticleItemList {
+  articles: IArticleItem[];
+}
+
 export interface IArticleItem {
-  id: number;
+  newsId: number;
   title: string;
   date: string;
   source: string;

--- a/src/interface/props.ts
+++ b/src/interface/props.ts
@@ -69,6 +69,7 @@ export interface IArticleItemList {
 }
 
 export interface IArticleItem {
+  id: number;
   newsId: number;
   title: string;
   date: string;


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #27

### 💡 작업내용
- 분야 탭 클릭 시 분야별 기사 조회

### 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/e82a91fa-5056-46fb-82fe-b068ae446769)

### 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
- 메모이제이션을 통한 최적화 필요